### PR TITLE
adds build date and version to about page. build_date.dart is include…

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -212,7 +212,7 @@ SPEC CHECKSUMS:
   in_app_review: 8efcf4a4d3ba72d5d776d29e5a268f1abf64d184
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  package_info_plus: 580e9a5f1b6ca5594e7c9ed5f92d1dfb2a66b5e1
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   share_plus: 011d6fb4f9d2576b83179a3a5c5e323202cdabcf

--- a/lib/about.dart
+++ b/lib/about.dart
@@ -10,14 +10,42 @@ import 'styles.dart';
 import 'package:in_app_review/in_app_review.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:believers_songbook/generated/build_date.dart';
+
+import 'package:intl/intl.dart';
 import 'dart:io' show Platform;
 
-class AboutPage extends StatelessWidget {
-  AboutPage({super.key});
+class AboutPage extends StatefulWidget {
+  const AboutPage({super.key});
+
+  @override
+  State<AboutPage> createState() => _AboutPageState();
+}
+
+class _AboutPageState extends State<AboutPage> {
   final InAppReview _inAppReview = InAppReview.instance;
+
+  String _version = '';
+  var _formattedDate = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPackageInfo();
+  }
+
+  Future<void> _loadPackageInfo() async {
+    final packageInfo = await PackageInfo.fromPlatform();
+    setState(() {
+      _version = packageInfo.version;
+      _formattedDate = DateFormat('dd MMMM yyyy').format(DateTime.parse(buildDate));
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
+
     return SelectionArea(
       child: Scaffold(
         appBar: AppBar(
@@ -204,9 +232,9 @@ class AboutPage extends StatelessWidget {
                       const Card(
                           child: Icon(Icons.handshake,
                               color: Styles.themeColor, size: 50.0)),
-                      const Text(
-                        'v1.8.0 - 21/07/24',
-                      ),
+
+                      Text('Version: $_version'),                      
+                      Text('Build date: $_formattedDate'),
                     ],
                   )),
                 ),

--- a/lib/generated/build_date.dart
+++ b/lib/generated/build_date.dart
@@ -1,0 +1,4 @@
+// GENERATED FILE - DO NOT MODIFY
+// Generated on 2025-04-11 14:24:17.007819Z
+
+const String buildDate = '2025-04-11T14:24:17.007819Z';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -430,21 +430,21 @@ packages:
     source: hosted
     version: "1.0.0"
   package_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: a75164ade98cb7d24cfd0a13c6408927c6b217fa60dee5a7ff5c116a58f28918
+      sha256: "7976bfe4c583170d6cdc7077e3237560b364149fcd268b5f53d95a991963b191"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.2"
+    version: "8.3.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
+      sha256: "6c935fb612dff8e3cc9632c2b301720c77450a126114126ffaafe28d2e87956c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.2.0"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
     sdk: flutter
   device_info_plus: ^10.1.2
   win32: ^5.5.3
+  package_info_plus: ^8.3.0
 
 flutter_icons:
   image_path: "assets/icon.png"

--- a/tool/build_date_generator.dart
+++ b/tool/build_date_generator.dart
@@ -1,0 +1,19 @@
+// tool/build_date_generator.dart
+
+import 'dart:io';
+
+void main() {
+  final now = DateTime.now().toUtc();
+  final fileContent = '''
+// GENERATED FILE - DO NOT MODIFY
+// Generated on $now
+
+const String buildDate = '${now.toIso8601String()}';
+''';
+
+  final outputFile = File('lib/generated/build_date.dart');
+  outputFile.createSync(recursive: true);
+  outputFile.writeAsStringSync(fileContent);
+
+  print('✅ Build date file generated at: ${outputFile.path}');
+}


### PR DESCRIPTION
This PR adds the build version (by accessing the version in pubspec.yaml) and the build date (by reading from `build_date.dart`) to the About page.
 
I have updated the "Songbook App Deployment" process by adding the command `dart tool/build_date_generator.dart`.

![image](https://github.com/user-attachments/assets/0f0af14f-7f46-44d2-b424-25211c3eab8f)
