### PR TITLE
hotfix: resolving issue with google signin on android and apple fresh installs endless spinner

### DIFF
--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -14,6 +14,14 @@
       },
       "oauth_client": [
         {
+          "client_id": "767948267709-9to47tahd3fgp8439p0nm9n3gciko2lv.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.ngonimujuru.songbook_for_believers",
+            "certificate_hash": "e2e14d80b2ab2d84ffdf7a25c9adf2d05e6dc790"
+          }
+        },
+        {
           "client_id": "767948267709-lvteea6cnsjqvjdat7bs87qij5v0c8tk.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -14,11 +14,11 @@
       },
       "oauth_client": [
         {
-          "client_id": "767948267709-9to47tahd3fgp8439p0nm9n3gciko2lv.apps.googleusercontent.com",
+          "client_id": "767948267709-2onb17u06ialb3qujpccavp0qk5ri9oo.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {
             "package_name": "com.ngonimujuru.songbook_for_believers",
-            "certificate_hash": "e2e14d80b2ab2d84ffdf7a25c9adf2d05e6dc790"
+            "certificate_hash": "96586a486e79adc4d7137c57f5792df3d13494a3"
           }
         },
         {

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -19,7 +19,13 @@ class AuthProvider extends ChangeNotifier {
   String? get uid => _user?.uid;
 
   AuthProvider() {
-    // Listen to auth state changes
+    // Seed _user synchronously from currentUser so that code reading isSignedIn
+    // immediately after construction gets the correct value. This matters on iOS
+    // where the Keychain survives app deletion: Firebase restores the session
+    // asynchronously via authStateChanges(), but currentUser is available right
+    // away after Firebase.initializeApp() has completed.
+    _user = _auth.currentUser;
+    // Listen to subsequent auth state changes
     _auth.authStateChanges().listen((User? user) {
       _user = user;
       notifyListeners();


### PR DESCRIPTION
Google Sign-In on Android was broken because the app's production signing certificate wasn't registered in Firebase. When Google Play publishes an app, it signs it with its own key. Firebase didn't know about that key, so Google rejected all sign-in attempts on Android. We pulled the production certificate from Google Play Console, registered it in Firebase, and updated the config file in the project.

On iOS, fresh installs after deletion were getting stuck on a loading spinner forever. iOS keeps login data saved even after you delete an app, but the app wasn't reading that saved state fast enough on startup. It would show the login screen, then detect the saved login a split second later and switch to a spinner with no way out. One line of code now reads the login state immediately at startup, so the app goes straight to the home screen instead of getting stuck.